### PR TITLE
Moving Torchbox docs onto github

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ If you don't want to run an Elasticsearch server in development or production, t
 * Sign up for an account at [dashboard.searchly.com/users/sign_up] (https://dashboard.searchly.com/users/sign_up)
 * Use your Searchly dashboard to create a new index, e.g. 'wagtaildemo'
 * Note the connection URL from your Searchly dashboard
-* Update *WAGTAILSEARCH_ES_URLS* and *WAGTAILSEARCH_ES_INDEX* in your local settings
-* Run *./manage.py update_index*
+* Update **WAGTAILSEARCH_ES_URLS** and **WAGTAILSEARCH_ES_INDEX** in your local settings
+* Run **./manage.py update_index**


### PR DESCRIPTION
Moving Torchbox docs onto wagtaildemo pages and add detailed info on deps etc.
