### PR TITLE
Added DEBUG = True to local.py

### DIFF
--- a/wagtaildemo/settings/local.py.example
+++ b/wagtaildemo/settings/local.py.example
@@ -2,6 +2,8 @@
 # Use this for any settings that are specific to this one installation, such as developer API keys.
 # local.py should not be checked in to version control.
 
+DEBUG = True
+
 EMBEDLY_KEY = 'get-one-from-http://embed.ly/'
 GOOGLE_MAPS_KEY = 'get-one-from-https://code.google.com/apis/console/?noredirect'
 


### PR DESCRIPTION
When using runserver with the stock local.py file the server refuses to run and kicks up a CommandError. Simply adding `DEBUG = True` corrects this.

```
./manage.py runserver 0.0.0.0:8000 --settings=wagtaildemo.settings.local
CommandError: You must set settings.ALLOWED_HOSTS if DEBUG is False.
```
