### PR TITLE
add python command to prevent error

### DIFF
--- a/etc/install/install.sh
+++ b/etc/install/install.sh
@@ -84,4 +84,4 @@ echo "workon $VIRTUALENV_NAME" >> /home/vagrant/.bashrc
 chmod a+x $PROJECT_DIR/manage.py
 
 # Django project setup
-su - vagrant -c "source $VIRTUALENV_DIR/bin/activate && cd $PROJECT_DIR && ./manage.py syncdb --noinput && ./manage.py migrate --noinput"
+su - vagrant -c "source $VIRTUALENV_DIR/bin/activate && cd $PROJECT_DIR && python manage.py syncdb --noinput && python manage.py migrate --noinput"


### PR DESCRIPTION
`./manage.py syncdb` causes `: No such file or directory` error when running `vagrant provision`

`python manage.py syncdb` fixes this. (same for `migrate`)
