### PR TITLE
fixing event (vcal) export

### DIFF
--- a/demo/utils.py
+++ b/demo/utils.py
@@ -29,7 +29,7 @@ def export_event(event, format='ical'):
         if event.time_from is not None:
             start_time = event.time_from
         else:
-            start_time = datetime.time.min
+            start_time = time.min
         if event.time_to is not None:
             end_time = event.time_to
         else:
@@ -75,4 +75,4 @@ def export_event(event, format='ical'):
 
     # Join components
     return '\r'.join(ical_components)
-    
+


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/wagtaildemo/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 114, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/vagrant/.virtualenvs/wagtaildemo/src/wagtail/wagtail/wagtailcore/views.py", line 11, in serve
    return request.site.root_page.specific.route(request, path_components)
  File "/home/vagrant/.virtualenvs/wagtaildemo/src/wagtail/wagtail/wagtailcore/models.py", line 300, in route
    return subpage.specific.route(request, remaining_components)
  File "/home/vagrant/.virtualenvs/wagtaildemo/src/wagtail/wagtail/wagtailcore/models.py", line 300, in route
    return subpage.specific.route(request, remaining_components)
  File "/home/vagrant/.virtualenvs/wagtaildemo/src/wagtail/wagtail/wagtailcore/models.py", line 305, in route
    return self.serve(request)
  File "/home/vagrant/wagtaildemo/demo/models.py", line 571, in serve
    export_event(self, 'ical'),
  File "/home/vagrant/wagtaildemo/demo/utils.py", line 32, in export_event
    start_time = datetime.time.min
AttributeError: 'method_descriptor' object has no attribute 'min'
```
