### PR TITLE
Added alisases to manage.py

### DIFF
--- a/etc/install/bashrc
+++ b/etc/install/bashrc
@@ -101,3 +101,6 @@ fi
 export WORKON_HOME=$HOME/.virtualenvs
 export PIP_DOWNLOAD_CACHE=$HOME/.pip_download_cache
 source /usr/local/bin/virtualenvwrapper.sh
+
+alias dj="/home/vagrant/.virtualenvs/wagtaildemo/bin/python /home/vagrant/wagtaildemo/manage.py"
+alias djrun="dj runserver 0.0.0.0:8000"


### PR DESCRIPTION
This commit adds two shell aliases:
- dj - Runs the manage.py script. This works anywhere inside the vagrant box and will always find manage.py (the alias uses the absolute path). Handy if you want to get to a django shell and you're in another directory. Use it like: "dj shell", "dj migrate", etc. Plus, its nicer than wriiting "python manage.py" or "./manage.py".
- djrun - Runs "dj runserver 0.0.0.0:8000". Much nicer than typing this out manually.
