### PR TITLE
missing wagtailimages_tags

### DIFF
--- a/demo/templates/demo/event_page.html
+++ b/demo/templates/demo/event_page.html
@@ -1,5 +1,5 @@
 {% extends "demo/base.html" %}
-{% load demo_tags wagtailcore_tags pageurl %}
+{% load demo_tags wagtailcore_tags pageurl wagtailimages_tags %}
 
 {% block content %}
     <div class="well">


### PR DESCRIPTION
Event Pages is giving me a 500 error due to speaker image because the page uses the image template tag  {% image speaker.image width-200 %}.

I've added wagtailimages_tags to correct problem.
