### PR TITLE
Fixed missing import in template tag

### DIFF
--- a/demo/templatetags/demo_tags.py
+++ b/demo/templatetags/demo_tags.py
@@ -1,3 +1,4 @@
+from datetime import date
 from django import template
 from django.conf import settings
 


### PR DESCRIPTION
events template tag for home page was not rendering due to missing import of `datetime.date`
