### PR TITLE
Add Deploy to Heroku button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn wagtaildemo.heroku_wsgi

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn wagtaildemo.heroku_wsgi
+web: sh ./heroku.sh

--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ Run the following commands:
     vagrant up
     vagrant ssh
       (then, within the SSH session:)
-    ./manage.py createsuperuser
     ./manage.py runserver 0.0.0.0:8000
 
 This will make the app accessible on the host machine as http://localhost:8111/ - you can access the Wagtail admin interface at http://localhost:8111/admin/ . The codebase is located on the host
-machine, exported to the VM as a shared folder; code editing and Git operations will generally be done on the host.
+machine, exported to the VM as a shared folder; code editing and Git operations will generally be done on the host. A superuser with the credentials ``admin / changeme`` is automatically created.
 
 ### Developing Wagtail
 The above setup is all you need for trying out the demo site and building Wagtail-powered sites. To develop Wagtail itself, you'll need a working copy of [the Wagtail codebase](https://github.com/torchbox/wagtail) alongside your demo site, shared with your VM so that it is picked up instead of the packaged copy of Wagtail. From the location where you cloned wagtaildemo:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/spapas/wagtaildemo)
+
 Wagtail demo
 =======================
 
@@ -35,7 +37,7 @@ The above setup is all you need for trying out the demo site and building Wagtai
         (edit Vagrantfile.local to specify the path to the wagtail codebase, if required)
     cp wagtaildemo/settings/local.py.example wagtaildemo/settings/local.py
         (uncomment the lines from 'import sys' onward, and edit the rest of local.py as appropriate)
-    
+
 If your VM is currently running, you'll then need to run `vagrant halt` followed by `vagrant up` for the changes to take effect.
 
 Setup (without Vagrant)

--- a/app.json
+++ b/app.json
@@ -4,12 +4,8 @@
   "repository": "https://github.com/spapas/wagtaildemo",
   "logo": "http://wagtail.io/static/wagtailsite/images/navlogo2.png",
   "keywords": ["wagtail", "django"],
-
-  "env": {
-    "DJANGO_SETTINGS_MODULE": {
-      "description": "Django settings module (please don't change it)",
-      "value": "wagtaildemo.settings.heroku"
-    }
+  "scripts": {
+    "postdeploy": "DJANGO_SETTINGS_MODULE=wagtaildemo.settings.heroku python manage.py migrate"
   },
   "addons": [
     "heroku-postgresql:hobby-dev"

--- a/app.json
+++ b/app.json
@@ -4,11 +4,12 @@
   "repository": "https://github.com/spapas/wagtaildemo",
   "logo": "http://wagtail.io/static/wagtailsite/images/navlogo2.png",
   "keywords": ["wagtail", "django"],
-  "scripts": {
-    "postdeploy": "python manage.py migrate && python manage.py load_initial_data"
-  },
+
   "env": {
-    "DJANGO_SETTINGS_MODULE": "wagtaildemo.settings.heroku"
+    "DJANGO_SETTINGS_MODULE": {
+      "description": "Django settings module (please don't change it)",
+      "value": "wagtaildemo.settings.heroku"
+    }
   },
   "addons": [
     "heroku-postgresql:hobby-dev"

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+  "name": "Wagtaildemo",
+  "description": "Wagtaildemo",
+  "repository": "https://github.com/spapas/wagtaildemo",
+  "logo": "http://wagtail.io/static/wagtailsite/images/navlogo2.png",
+  "keywords": ["wagtail", "django"],
+  "scripts": {
+    "postdeploy": "python manage.py migrate && python manage.py load_initial_data"
+  },
+  "env": {
+    "DJANGO_SETTINGS_MODULE": "wagtaildemo.settings.heroku"
+  },
+  "addons": [
+    "heroku-postgresql:hobby-dev"
+  ]
+}

--- a/demo/fixtures/demo.json
+++ b/demo/fixtures/demo.json
@@ -1035,5 +1035,23 @@
         "name": "writer", 
         "slug": "writer"
     }
+},
+{
+    "fields": {
+        "email": "",
+        "username": "admin",
+        "last_name": "",
+        "last_login": "2015-01-15T10:15:46.942Z",
+        "is_superuser": true,
+        "is_active": true,
+        "groups": [],
+        "date_joined": "2015-01-15T10:13:48.969Z",
+        "is_staff": true,
+        "user_permissions": [],
+        "first_name": "",
+        "password": "pbkdf2_sha256$15000$hbmFjDx3rL12$lfU7j6YuVlKmUPChuiSXsXFhIgrejJGuWvWj5wxlRjQ="
+    },
+    "model": "auth.user",
+    "pk": 1
 }
 ]

--- a/heroku.sh
+++ b/heroku.sh
@@ -1,4 +1,3 @@
-export DJANGO_SETTINGS_MODULE=wagtaildemo.settings.heroku 
-python manage.py migrate
+export DJANGO_SETTINGS_MODULE=wagtaildemo.settings.heroku
 python manage.py load_initial_data
 gunicorn wagtaildemo.heroku_wsgi

--- a/heroku.sh
+++ b/heroku.sh
@@ -1,0 +1,4 @@
+export DJANGO_SETTINGS_MODULE=wagtaildemo.settings.heroku 
+python manage.py migrate
+python manage.py load_initial_data
+gunicorn wagtaildemo.heroku_wsgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements/heroku.txt

--- a/requirements/heroku.txt
+++ b/requirements/heroku.txt
@@ -1,0 +1,5 @@
+-r base.txt
+
+dj-database-url==0.3.0
+dj-static==0.0.6
+gunicorn==19.1.1

--- a/requirements/heroku.txt
+++ b/requirements/heroku.txt
@@ -3,3 +3,4 @@
 dj-database-url==0.3.0
 dj-static==0.0.6
 gunicorn==19.1.1
+

--- a/wagtaildemo/heroku_wsgi.py
+++ b/wagtaildemo/heroku_wsgi.py
@@ -1,0 +1,4 @@
+from django.core.wsgi import get_wsgi_application
+from dj_static import Cling
+
+application = Cling(get_wsgi_application())

--- a/wagtaildemo/settings/heroku.py
+++ b/wagtaildemo/settings/heroku.py
@@ -1,4 +1,5 @@
 from .base import *
+import os
 
 DEBUG = True
 

--- a/wagtaildemo/settings/heroku.py
+++ b/wagtaildemo/settings/heroku.py
@@ -1,0 +1,18 @@
+from .base import *
+
+DEBUG = True
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+# BASE_URL required for notification emails
+BASE_URL = 'http://localhost:8111'
+
+import dj_database_url
+DATABASES['default'] =  dj_database_url.config()
+DATABASES = {'default': dj_database_url.config(default='postgres://postgres@localhost:5432/wagtaildemo')}
+
+
+try:
+    from .local import *
+except ImportError:
+    pass


### PR DESCRIPTION
This adds a deploy to heroku button (https://devcenter.heroku.com/articles/heroku-button) to Wagtaildemo.

It can be tested right now by clicking the button (at spapas/wagtaildemo), but it will use my fork instead of torchbox/wagtaildemo. After merging we need to change the ``README.md`` and ``app.json`` to point to the correct repository.

Finally, because of how Heroku works, the filesystem is read only so the uploaded images that would be copied through ``load_initial_data`` to the ``MEDIA`` folder will not be copied. 