### PR TITLE
Heroku fixes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn wagtaildemo.heroku_wsgi
+web: django-admin.py load_initial_data && gunicorn wagtaildemo.heroku_wsgi

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: django-admin.py load_initial_data && gunicorn wagtaildemo.heroku_wsgi
+web: gunicorn wagtaildemo.heroku_wsgi

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: sh ./heroku.sh
+web: gunicorn wagtaildemo.heroku_wsgi

--- a/app.json
+++ b/app.json
@@ -4,8 +4,11 @@
   "repository": "https://github.com/torchbox/wagtaildemo",
   "logo": "http://wagtail.io/static/wagtailsite/images/navlogo2.png",
   "keywords": ["wagtail", "django"],
+  "env": {
+    "DJANGO_SETTINGS_MODULE": "wagtaildemo.settings.heroku"
+  },
   "scripts": {
-    "postdeploy": "DJANGO_SETTINGS_MODULE=wagtaildemo.settings.heroku python manage.py migrate"
+    "postdeploy": "django-admin.py migrate && echo 'from wagtail.wagtailimages.models import Rendition; Rendition.objects.all().delete()' | django-admin.py shell"
   },
   "addons": [
     "heroku-postgresql:hobby-dev"

--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     "DJANGO_SETTINGS_MODULE": "wagtaildemo.settings.heroku"
   },
   "scripts": {
-    "postdeploy": "django-admin.py migrate && echo 'from wagtail.wagtailimages.models import Rendition; Rendition.objects.all().delete()' | django-admin.py shell"
+    "postdeploy": "django-admin.py migrate && django-admin.py load_initial_data && echo 'from wagtail.wagtailimages.models import Rendition; Rendition.objects.all().delete()' | django-admin.py shell"
   },
   "addons": [
     "heroku-postgresql:hobby-dev"

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,3 @@
+# Copy image files into media folder
+mkdir -p media/original_images
+cp demo/fixtures/images/* media/original_images/

--- a/heroku.sh
+++ b/heroku.sh
@@ -1,3 +1,0 @@
-export DJANGO_SETTINGS_MODULE=wagtaildemo.settings.heroku
-python manage.py load_initial_data
-gunicorn wagtaildemo.heroku_wsgi


### PR DESCRIPTION
This makes the following changes to the heroku config:
 - Images are now copied with ``cp`` instead of ``load_initial_data`` (``load_initial_data`` will only run on first deploy)
 - Moved image copying code into the post_compile hook rather than Procfile (a little neater and may improve boot speed)
 - Delete rendition database records on every deploy (this is because the renditions images get clobbered on every deploy)
 - Configure ``DJANGO_SETTINGS_MODULE`` with "env" section of app.json