### PR TITLE
Updated host for database to localhost

### DIFF
--- a/wagtaildemo/settings/base.py
+++ b/wagtaildemo/settings/base.py
@@ -22,7 +22,7 @@ DATABASES = {
         'NAME': 'wagtaildemo',
         'USER': 'postgres',
         'PASSWORD': '',
-        'HOST': '',  # Set to empty string for localhost.
+        'HOST': 'localhost',  
         'PORT': '',  # Set to empty string for default.
         'CONN_MAX_AGE': 600,  # number of seconds database connections should persist for
     }


### PR DESCRIPTION
leaving the host entry empty brings an error. You have to set it to localhost. 

Without localhost: 

(env_wagtail_tobnic)root@v2201404286118088:~/pythonWeb/wagtail_tobnic# python manage.py migrate
/root/pythonWeb/env_wagtail_tobnic/lib/python3.4/site-packages/treebeard/mp_tree.py:102: RemovedInDjango18Warning: `MP_NodeManager.get_query_set` method should be renamed `get_queryset`.
  class MP_NodeManager(models.Manager):

Traceback (most recent call last):
  File "/root/pythonWeb/env_wagtail_tobnic/lib/python3.4/site-packages/django/db/backends/__init__.py", line 133, in ensure_connection
    self.connect()
  File "/root/pythonWeb/env_wagtail_tobnic/lib/python3.4/site-packages/django/db/backends/__init__.py", line 122, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/root/pythonWeb/env_wagtail_tobnic/lib/python3.4/site-packages/django/db/backends/postgresql_psycopg2/base.py", line 134, in get_new_connection
    return Database.connect(**conn_params)
  File "/root/pythonWeb/env_wagtail_tobnic/lib/python3.4/site-packages/psycopg2/__init__.py", line 164, in connect
    conn = _connect(dsn, connection_factory=connection_factory, async=async)
psycopg2.OperationalError: FATAL:  Peer authentication failed for user "wagtail_tobnic"