### PR TITLE
Remove celery and gunicorn

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,5 +1,3 @@
 -r base.txt
-django-celery==3.1.1
-gunicorn==18.0
 django-redis==3.8.2
 elasticsearch==1.2.0

--- a/wagtaildemo/settings/production.py
+++ b/wagtaildemo/settings/production.py
@@ -11,13 +11,6 @@ WAGTAILSEARCH_BACKENDS = {
 }
 
 
-INSTALLED_APPS+= (
-    'djcelery',
-    'kombu.transport.django',
-    'gunicorn',    
-)
-
-
 CACHES = {
     'default': {
         'BACKEND': 'redis_cache.cache.RedisCache',
@@ -36,14 +29,6 @@ TEMPLATE_LOADERS = (
         'django.template.loaders.app_directories.Loader',
     )),
 )
-
-# CELERY SETTINGS
-import djcelery
-djcelery.setup_loader()
-
-BROKER_URL = 'redis://'
-CELERY_SEND_TASK_ERROR_EMAILS = True
-CELERYD_LOG_COLOR = False
 
 
 try:


### PR DESCRIPTION
Celery is not needed and Gunicorn shouldn't be imposed on anyone as Wagtail doesn't have any opinions on what WSGI server runs it (it is still being installed in heroku.txt though).