### PR TITLE
Add search view

### DIFF
--- a/demo/templates/demo/includes/search_box.html
+++ b/demo/templates/demo/includes/search_box.html
@@ -1,8 +1,8 @@
-<form action="{% url 'wagtailsearch_search' %}" class="form-inline" method="get">
+<form action="{% url 'search' %}" class="form-inline" method="get">
     <div class="row">
         <div class="col-sm-5">
             <div class="input-group">
-                <input type="text" name="q" class="form-control" />
+                <input type="text" name="query" class="form-control" />
                 <div class="input-group-btn">
                     <button type="submit" class="btn btn-primary">
                         <i class="glyphicon glyphicon-search"></i> Search

--- a/demo/templates/demo/search_results.html
+++ b/demo/templates/demo/search_results.html
@@ -11,21 +11,19 @@
 
 
 {% block content %}
-    {% with query.editors_picks.all as editors_picks %}
-        {% if editors_picks %}
-            <div class="well">
+    {% if search_picks %}
+        <div class="well">
             <h3>Editors picks</h3>
-                <ul>
-                    {% for editors_pick in editors_picks %}
-                        <li>
-                            <h4><a href="{% pageurl editors_pick.page %}">{{ editors_pick.page.title }}</a></h4>
-                            <p>{{ editors_pick.description|safe }}</p>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        {% endif %}
-    {% endwith %}
+            <ul>
+                {% for pick in search_picks %}
+                    <li>
+                        <h4><a href="{% pageurl pick.page %}">{{ pick.page.title }}</a></h4>
+                        <p>{{ pick.description|safe }}</p>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
 
     {% if search_results %}
         <ul>
@@ -38,7 +36,7 @@
                 </li>
             {% endfor %}
         </ul>
-    {% elif request.GET.q %}
+    {% elif search_query %}
         No results found
     {% else %}
         You didn’t search anything!

--- a/demo/templates/demo/tags/top_menu.html
+++ b/demo/templates/demo/tags/top_menu.html
@@ -29,9 +29,9 @@
                     </li>       
                 {% endfor %}
             </ul>
-            <form class="navbar-form navbar-right" role="search" action="{% url 'wagtailsearch_search' %}" method="get">
+            <form class="navbar-form navbar-right" role="search" action="{% url 'search' %}" method="get">
                 <div class="input-group">
-                    <input type="text" name="q" class="form-control" placeholder="Search…" value="{{ request.GET.q}}" />
+                    <input type="text" name="query" class="form-control" placeholder="Search…" value="{{ search_query }}" />
                     <div class="input-group-btn">
                         <button type="submit" class="btn btn-default">
                             <i class="glyphicon glyphicon-search"></i>

--- a/demo/views.py
+++ b/demo/views.py
@@ -1,0 +1,38 @@
+from django.shortcuts import render
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailsearch.models import Query, EditorsPick
+
+
+def search(request):
+    # Search
+    search_query = request.GET.get('query', None)
+    if search_query:
+        search_results = Page.objects.live().search(search_query)
+        query = Query.get(search_query)
+
+        # Record hit
+        query.add_hit()
+
+        # Get search picks
+        search_picks = query.editors_picks.all()
+    else:
+        search_results = Page.objects.none()
+        search_picks = EditorsPick.objects.none()
+
+    # Pagination
+    page = request.GET.get('page', 1)
+    paginator = Paginator(search_results, 10)
+    try:
+        search_results = paginator.page(page)
+    except PageNotAnInteger:
+        search_results = paginator.page(1)
+    except EmptyPage:
+        search_results = paginator.page(paginator.num_pages)
+
+    return render(request, 'demo/search_results.html', {
+        'search_query': search_query,
+        'search_results': search_results,
+        'search_picks': search_picks,
+    })

--- a/wagtaildemo/settings/base.py
+++ b/wagtaildemo/settings/base.py
@@ -216,6 +216,3 @@ LOGGING = {
 # WAGTAIL SETTINGS
 
 WAGTAIL_SITE_NAME = 'wagtaildemo'
-
-# Override the search results template for wagtailsearch
-WAGTAILSEARCH_RESULTS_TEMPLATE = 'demo/search_results.html'

--- a/wagtaildemo/urls.py
+++ b/wagtaildemo/urls.py
@@ -4,9 +4,10 @@ from django.conf import settings
 from django.contrib import admin
 
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
-from wagtail.wagtailsearch import urls as wagtailsearch_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
+
+from demo import views
 
 
 admin.autodiscover()
@@ -16,8 +17,9 @@ urlpatterns = patterns('',
     url(r'^django-admin/', include(admin.site.urls)),
 
     url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^search/', include(wagtailsearch_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
+
+    url(r'search/$', views.search, name='search'),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism


### PR DESCRIPTION
Wagtail's built-in search view is tricky to extend (features such as filters are difficult to implement in a generic way). I think we should start implementing search views in the project instead of in Wagtail core.

 - Easier for developers to change and doesn't require settings
 - The builtin frontend search view goes a little bit against Wagtails philosophy of not having any opinions on how the frontend of the site should be implemented
 - It provides a good example of the API for searching pages and shows demo users that Wagtail works well with regular Django views