### PR TITLE
Fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Wagtail demo
 
 This is a demonstration site implemented with [Wagtail CMS](http://wagtail.io).
 
-To create your own site from scratch we strongly recommend the ``wagtail start`` command, explained in the [Wagtail CMS Documentation](http://wagtail.readthedocs.org/en/latest/getting_started/creating_your_project.html) however this demo provides some useful examples.
+To create your own site from scratch we strongly recommend the ``wagtail start`` command, explained in the [Wagtail CMS Documentation](http://wagtail.readthedocs.org/en/latest/getting_started/) however this demo provides some useful examples.
 
 Setup with Vagrant (recommended)
 -----


### PR DESCRIPTION
First link to the docs was a 404 :) http://wagtail.readthedocs.org/en/latest/getting_started/ seems like the right place to link to, but it may not be.

Congratulations for Wagtail's `1.0`!