### PR TITLE
Remove PATH_TO_WAGTAIL hack in settings/local.py

### DIFF
--- a/Vagrantfile.local.example
+++ b/Vagrantfile.local.example
@@ -14,5 +14,6 @@
 config.vm.synced_folder "../wagtail", "/home/vagrant/wagtail"
 
 
-# You'll also need to tweak the Python path so that it picks up this instance of
-# Wagtail rather than the packaged one - see wagtaildemo/settings/local.py.example.
+# You'll also need to configure your Python environment within the VM to pick up this
+# instance of Wagtail rather than the packaged one; usually this is done by running
+# `./setup.py develop` within the checked-out Wagtail codebase.

--- a/wagtaildemo/settings/local.py.example
+++ b/wagtaildemo/settings/local.py.example
@@ -26,15 +26,3 @@ SECRET_KEY = 'enter-a-long-unguessable-string-here'
 # DEBUG_TOOLBAR_CONFIG = {
 #     'INTERCEPT_REDIRECTS': False,
 # }
-
-
-# If you're developing Wagtail itself (as opposed to building a Wagtail-powered site), you'll
-# want to tweak the Python path so that it picks up your working copy of the Wagtail code
-# rather than the packaged copy - uncomment the lines below to do that.
-# Here we assume that you have it in a 'wagtail' directory at the same level as your
-# 'wagtaildemo' checkout - adjust the path as appropriate.
-
-# import sys
-# import os
-# PATH_TO_WAGTAIL = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'wagtail')
-# sys.path.insert(1, PATH_TO_WAGTAIL)


### PR DESCRIPTION
It doesn't work properly (see https://github.com/torchbox/wagtaildemo/issues/79) and ./setup.py develop is the proper way of doing it.

To be merged after the documentation fix https://github.com/torchbox/wagtail/pull/1759 is merged.