### PR TITLE
Replace HTTP and protocol-relative links by HTTPS equivalents

### DIFF
--- a/demo/static/demo/css/main.scss
+++ b/demo/static/demo/css/main.scss
@@ -3,7 +3,7 @@ $padding-vertical: 15px;
 $wagtail-color: rgb(0, 127, 127);
 $html-background-color: whitesmoke;
 
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700);
 
 html {
     background-color: $html-background-color;

--- a/demo/templates/demo/base.html
+++ b/demo/templates/demo/base.html
@@ -25,16 +25,14 @@
         {% block extra_css %}{% endblock %} {# Override this block in individual templates in order to add stylesheets on a template by template basis #}
 
         {# Javascript that needs to be called from head e.g. google analytics snippet and bootstrap shivs #}
-        <script type="text/javascript">
-              var _gaq = _gaq || [];
-              _gaq.push(['_setAccount', 'UA-xxxxxxx-x']);
-              _gaq.push(['_trackPageview']);
+        <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-              (function() {
-                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-              })();
+        ga('create', 'UA-XXXXX-Y', 'auto');
+        ga('send', 'pageview');
         </script>
         <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
         <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/demo/templates/demo/base.html
+++ b/demo/templates/demo/base.html
@@ -13,7 +13,7 @@
         <meta name="description" content="{% if self.search_description %}{{ self.search_description }}{% endif %}">
 
         {# External stylesheets #}
-        <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
 
         {# Local static assets such as css, images and javascrpt should be stored at [yourapp]/static/[yourapp]/... #}
         {% compress css %}

--- a/demo/templates/demo/base.html
+++ b/demo/templates/demo/base.html
@@ -13,7 +13,7 @@
         <meta name="description" content="{% if self.search_description %}{{ self.search_description }}{% endif %}">
 
         {# External stylesheets #}
-        <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
+        <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
 
         {# Local static assets such as css, images and javascrpt should be stored at [yourapp]/static/[yourapp]/... #}
         {% compress css %}
@@ -73,8 +73,8 @@
         {% adverts %}
 
         {# External javascript #}
-        <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
-        <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+        <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
 
         {% compress js %}
             <script src="{% static "demo/js/vendor/fluidvids.js" %}"></script>
@@ -84,6 +84,6 @@
         {% endcompress %}
 
         {% block extra_js %}{% endblock %} {# Override this block in individual templates in order to add javascript on a template by template basis #}
-        
+
     </body>
 </html>

--- a/demo/templates/demo/contact_page.html
+++ b/demo/templates/demo/contact_page.html
@@ -17,6 +17,6 @@
 
         <div class="page-header"><h3>Map</h3></div>
 
-        <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ self.post_code }}&amp;zoom=13&amp;size=800x400&amp;maptype=roadmap&amp;sensor=false&amp;markers=color:green|{{ self.post_code }}{% if google_maps_key %}&amp;key={{ google_maps_key }}{% endif %}" />
+        <img src="https://maps.googleapis.com/maps/api/staticmap?center={{ self.post_code }}&amp;zoom=13&amp;size=800x400&amp;maptype=roadmap&amp;sensor=false&amp;markers=color:green|{{ self.post_code }}{% if google_maps_key %}&amp;key={{ google_maps_key }}{% endif %}" />
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
The HTTP origins cause the following issue in modern browsers when deployed to Heroku:

```
Mixed Content: The page at 'https://wagtaildemo-springload.herokuapp.com/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700'. This request has been blocked; the content must be served over HTTPS.
```

Only the Google Fonts and Google Maps URLs are really problematic here, but protocol-relative URLs have long been considered an anti-pattern so I also moved those to HTTPS. The GA snippet included is quite old and was also protocol-relative, so I replaced it with the latest from https://developers.google.com/analytics/devguides/collection/analyticsjs/.

Finally, I noticed that this was using two different Bootstrap CDNs – NetDNA for the CSS, MaxCDN for the JS. The latest Bootstrap docs refere to MaxCDN, so I replaced the NetDNA URL.